### PR TITLE
feat: Bump Composer Deps

### DIFF
--- a/configure.php
+++ b/configure.php
@@ -267,6 +267,8 @@ if (! $useUpdateChangelogWorkflow) {
     safeUnlink(__DIR__.'/.github/workflows/update-changelog.yml');
 }
 
+confirm('Bump up Composer dependencies?') && run('composer bump');
+
 confirm('Execute `composer install`?') && run('composer install');
 
 confirm('Let this script delete itself?', true) && unlink(__FILE__);


### PR DESCRIPTION
This PR adds a new option to bump up your Composer dependencies before installing, keeping things up to date. It is `false` by default.